### PR TITLE
DI-808

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Andre Rosa <andre_rosa@hms.harvard.edu>
 ### generate self-signed certificate (if they don't exist)
 ### default files (will be overwritten by gencerts.sh)
 
-RUN apt-get update && apt-get install openssl
+RUN apt-get update && apt-get -y install openssl
 
 ENV CERT_DIR /etc/nginx/certs
 


### PR DESCRIPTION
dockerfile build fails. Needed -y in install. How did I not run into
this problem before?