### PR TITLE
PICSURE-77 add whitelist capability

### DIFF
--- a/deployments/irct/README.md
+++ b/deployments/irct/README.md
@@ -32,7 +32,7 @@ Latest available Docker image versions:
 
 -   _Required_: `*_version=`, `IRCTMYSQLADDRESS=`, `ENV_FILE=`.
 
--   Optional: `STACK_ENV=`, `STACK_NAME`
+-   Optional: `STACK_ENV=`, `STACK_NAME`, `WHITELIST_PATH`
 
 ```bash
 # versions
@@ -53,6 +53,9 @@ ENV_FILE=sample_project.env
 ## labeling
 STACK_ENV=
 STACK_NAME=
+
+#To designate a whistlist file.  Should be named whitelist.json
+WHITELIST_PATH=
 ```
 
 ### For Local Database Purposes (localdb.yml)
@@ -99,6 +102,8 @@ IRCTMYSQLPASS=
 MYSQL_ROOT_PASSWORD=
 
 IRCT_USER_FIELD=email
+#Make sure the name of this file matches your file, if used
+WHITELIST_PATH=/whitelist-data/whitelist.json
 
 # required for any JWT tokens generation,
 CLIENT_ID=

--- a/deployments/irct/dev.yml
+++ b/deployments/irct/dev.yml
@@ -39,6 +39,9 @@ services:
       - 8787:8787
     volumes:
       - ${LOCAL_IRCT}/IRCT-CL.war:/opt/jboss/wildfly/standalone/deployments/IRCT-CL.war:cached
+      - ${LOCAL_IRCT_CONFIG}:/opt/jboss/wildfly/standalone/configuration/standalone.xml
+      - ${WHITELIST_PATH}:/whitelist-data:ro
+
 
   irct-init:
     image: dbmi/irct-init:${irct_init_version}
@@ -46,6 +49,12 @@ services:
       - ${ENV_FILE}
     networks:
       - public
+    volumes:
+      - ${IRCT_SCRIPTS}:/scratch/irct/sql:rw
+
+volumes:
+    whitelist-data:
+
 
 networks:
     public:

--- a/deployments/irct/env.env
+++ b/deployments/irct/env.env
@@ -11,6 +11,9 @@ mysql_version=
 STACK_ENV=
 STACK_NAME=
 
+#Path to whitelist file on host machine
+WHITELIST_PATH=
+
 ## database host (required by container_name yaml tag)
 # this sets a DNS entry for the container
 IRCTMYSQLADDRESS=
@@ -25,6 +28,7 @@ ENV_FILE=sample_project.env
 
 ## local volumes
 LOCAL_IRCT=
+
 
 # local port (port must be available on docker host, check for conflicts -Andre)
 DOCKER_IRCT_DB_PORT=

--- a/deployments/irct/sample_project.env
+++ b/deployments/irct/sample_project.env
@@ -13,7 +13,7 @@ IRCTMYSQLPASS=
 MYSQL_ROOT_PASSWORD=
 
 IRCT_USER_FIELD=email
-
+WHITELIST_PATH=/whitelist-data/whitelist.json
 # required for any JWT tokens generation,
 CLIENT_ID=
 CLIENT_SECRET=


### PR DESCRIPTION
Half of PICSURE-77 was done under DI-1067, but this should allow whitelist capability.  This commit adds the volume mapping to the whitelist file into dev.yml.  That code would need to be put into whichever .yml file is used for deployment requiring whitelists.